### PR TITLE
Fix schema for video portraits

### DIFF
--- a/Sources/BbcNews/Models/Story/FDVideoPortraitStory.swift
+++ b/Sources/BbcNews/Models/Story/FDVideoPortraitStory.swift
@@ -16,7 +16,9 @@ public struct FDVideoPortraitStory: Codable, Equatable, Hashable {
     public var id: String
 
     /// The URL of the poster image for the video story.
-    public var url: URL
+    ///
+    /// This is deprecated in favour of `image`.
+    @FailableCodable public var url: URL?
 
     /// The title of the video story.
     public var text: String
@@ -27,6 +29,9 @@ public struct FDVideoPortraitStory: Codable, Equatable, Hashable {
     /// The video media to display in the story.
     public var media: FDMedia
 
+    /// The poster image for the video story.
+    public var image: FDImage?
+
     /// Creates a new portrait video story.
     ///
     /// - Parameters:
@@ -35,13 +40,15 @@ public struct FDVideoPortraitStory: Codable, Equatable, Hashable {
     ///   - text: The title of the video story.
     ///   - subtext: The short description of the video story.
     ///   - media: The video media to display in the story.
-    public init(id: String, url: URL, text: String, subtext: String, media: FDMedia) {
+    ///   - image: The poster image for the video story.
+    public init(id: String, url: URL? = nil, text: String, subtext: String, media: FDMedia, image: FDImage? = nil) {
         self.type = "VideoPortraitStory"
         self.id = id
         self.url = url
         self.text = text
         self.subtext = subtext
         self.media = media
+        self.image = image
     }
 
     public func hash(into hasher: inout Hasher) {

--- a/Sources/BbcNews/Models/Story/Media/FDMediaMetaData.swift
+++ b/Sources/BbcNews/Models/Story/Media/FDMediaMetaData.swift
@@ -24,8 +24,11 @@ public struct FDMediaMetadata: Codable, Equatable, Hashable {
     /// The 64-bit timestamp of the time the media item was last updated.
     public var timestamp: Date
 
+    /// The guidance message for the video.
+    public var guidanceMessage: String?
+
     /// A URL that displays content associated to the media item.
-    public var associatedContentUrl: URL?
+    @FailableCodable public var associatedContentUrl: URL?
 
     /// Is advertising allowed with the media item.
     public var allowAdvertising: Bool
@@ -38,6 +41,7 @@ public struct FDMediaMetadata: Codable, Equatable, Hashable {
     ///   - caption: The caption to display with the media item.
     ///   - captionWithStyle: The caption with styling items.
     ///   - timestamp: The 64-bit timestamp of the time the media item was last updated.
+    ///   - guidanceMessage: The guidance message for the video.
     ///   - associatedContentUrl: A URL that displays content associated to the media item.
     ///   - allowAdvertising: Is advertising allowed with the media item.
     public init(
@@ -46,6 +50,7 @@ public struct FDMediaMetadata: Codable, Equatable, Hashable {
         caption: String,
         captionWithStyle: FDAttributedText? = nil,
         timestamp: Date,
+        guidanceMessage: String? = nil,
         associatedContentUrl: URL? = nil,
         allowAdvertising: Bool
     ) {
@@ -54,6 +59,7 @@ public struct FDMediaMetadata: Codable, Equatable, Hashable {
         self.caption = caption
         self.captionWithStyle = captionWithStyle
         self.timestamp = timestamp
+        self.guidanceMessage = guidanceMessage
         self.associatedContentUrl = associatedContentUrl
         self.allowAdvertising = allowAdvertising
     }

--- a/Sources/BbcNews/Utils/FailableCodable.swift
+++ b/Sources/BbcNews/Utils/FailableCodable.swift
@@ -1,0 +1,42 @@
+//
+//  FailableCodable.swift
+//  BbcNews
+//
+//  Created by Bilaal Rashid on 08/07/2024.
+//
+
+import Foundation
+
+/// A property wrapper that decodes an empty value as nil.
+@propertyWrapper
+public struct FailableCodable<Wrapped>: Codable, Equatable, Hashable where Wrapped: Codable, Wrapped: Equatable, Wrapped: Hashable {
+    /// The wrapped value of the property wrapper.
+    public var wrappedValue: Wrapped?
+
+    /// Creates a new `FailableCodable` property wrapper.
+    ///
+    /// - Parameter wrappedValue: The raw value to be wrapped.
+    public init(wrappedValue: Wrapped?) {
+        self.wrappedValue = wrappedValue
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.wrappedValue = try? container.decode(Wrapped.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.wrappedValue)
+    }
+}
+
+extension KeyedDecodingContainer {
+    func decode<Wrapped: Codable>(_ type: FailableCodable<Wrapped>.Type, forKey key: K) throws -> FailableCodable<Wrapped> {
+        if let value = try self.decodeIfPresent(type, forKey: key) {
+            return value
+        }
+
+        return FailableCodable(wrappedValue: nil)
+    }
+}

--- a/Tests/BbcNewsTests/Resources/Story4.json
+++ b/Tests/BbcNewsTests/Resources/Story4.json
@@ -1,0 +1,122 @@
+{
+    "data": {
+        "metadata": {
+            "name": "Cornwall ice cream van whipped out to sea",
+            "allowAdvertising": true,
+            "lastUpdated": 1720457899000
+        },
+        "items": [
+            {
+                "id": "urn:bbc:pips:pid:p0j950j4",
+                "url": "",
+                "text": "Cornwall ice cream van whipped out to sea",
+                "media": {
+                    "source": {
+                        "id": "p0j950j8",
+                        "type": "VIDEO",
+                        "isLive": false,
+                        "canAutoPlay": true,
+                        "duration": 0,
+                        "aspectRatio": 1.7777777777777777,
+                        "episodePid": "p0j950j4"
+                    },
+                    "metadata": {
+                        "title": "Cornwall ice cream van whipped out to sea",
+                        "summary": "Cornwall ice cream van whipped out to sea",
+                        "caption": "Cornwall ice cream van whipped out to sea",
+                        "timestamp": 1720457899000,
+                        "guidanceMessage": "",
+                        "associatedContentUrl": "",
+                        "allowAdvertising": true
+                    },
+                    "image": {
+                        "source": {
+                            "url": "https://ichef.bbci.co.uk/images/ic/{width}xn/p0j9519n.jpg",
+                            "sizingMethod": {
+                                "type": "SPECIFIC_WIDTHS",
+                                "widthToken": "{width}",
+                                "widths": [
+                                    80,
+                                    128,
+                                    160,
+                                    240,
+                                    288,
+                                    320,
+                                    400,
+                                    432,
+                                    480,
+                                    512,
+                                    576,
+                                    640,
+                                    720,
+                                    768,
+                                    800,
+                                    960,
+                                    1024,
+                                    1136,
+                                    1152,
+                                    1200,
+                                    1280,
+                                    1440,
+                                    1536,
+                                    1600,
+                                    1920
+                                ]
+                            }
+                        },
+                        "metadata": {
+                            "altText": "Yellow ice cream van sits in the waves as people look on"
+                        },
+                        "type": "Image"
+                    },
+                    "type": "Media"
+                },
+                "subtext": "",
+                "image": {
+                    "source": {
+                        "url": "https://ichef.bbci.co.uk/images/ic/{width}xn/p0j9519n.jpg",
+                        "sizingMethod": {
+                            "type": "SPECIFIC_WIDTHS",
+                            "widthToken": "{width}",
+                            "widths": [
+                                80,
+                                128,
+                                160,
+                                240,
+                                288,
+                                320,
+                                400,
+                                432,
+                                480,
+                                512,
+                                576,
+                                640,
+                                720,
+                                768,
+                                800,
+                                960,
+                                1024,
+                                1136,
+                                1152,
+                                1200,
+                                1280,
+                                1440,
+                                1536,
+                                1600,
+                                1920
+                            ]
+                        }
+                    },
+                    "metadata": {
+                        "altText": "Yellow ice cream van sits in the waves as people look on"
+                    },
+                    "type": "Image"
+                },
+                "type": "VideoPortraitStory"
+            }
+        ],
+        "trackers": [],
+        "type": "ContentResponse"
+    },
+    "contentType": "application/json; charset=utf-8"
+}

--- a/Tests/BbcNewsTests/SchemaTests.swift
+++ b/Tests/BbcNewsTests/SchemaTests.swift
@@ -15,6 +15,7 @@ final class SchemaTests: XCTestCase {
         try self.executeResultTest(file: "Story")
         try self.executeResultTest(file: "Story2")
         try self.executeResultTest(file: "Story3")
+        try self.executeResultTest(file: "Story4")
         try self.executeResolverResultTest(file: "ResolverResponse")
     }
 

--- a/openapi/pre-7/components/schemas/FDMediaMetadata.yaml
+++ b/openapi/pre-7/components/schemas/FDMediaMetadata.yaml
@@ -28,8 +28,13 @@ properties:
     description: The 64-bit timestamp of the time the media item was last updated.
     type: integer
     format: int64
+  guidanceMessage:
+    description: The guidance message for the video.
+    type: string
   associatedContentUrl:
-    description: A URL that displays content associated to the media item.
+    description: >-
+      A URL that displays content associated to the media item. This can return a
+      blank string when empty.
     type: string
     format: uri
     example: https://www.bbc.co.uk/news/world-europe-69035174

--- a/openapi/pre-7/components/schemas/FDVideoPortraitStory.yaml
+++ b/openapi/pre-7/components/schemas/FDVideoPortraitStory.yaml
@@ -18,7 +18,9 @@ properties:
     type: string
     example: p0hyzfgw
   url:
-    description: The URL of the poster image for the video story.
+    description: >-
+      The URL of the poster image for the video story. This is deprecated in favour
+      of `image` and will return a blank string.
     type: string
     format: uri
     example: http://c.files.bbci.co.uk/BD44/production/_133325484_meteorstill1.jpg
@@ -34,3 +36,5 @@ properties:
       the night sky.
   media:
     $ref: ./FDMedia.yaml
+  image:
+    $ref: ./FDImage.yaml


### PR DESCRIPTION
# Related issues

Closes #14 

# Summary of changes

- Handle empty strings for URLs in `FDVideoPortraitStory` and `FDMediaMetadata`
- Add `guidanceMessage` property to `FDMediaMetadata`
- Add test case
- Update OpenAPI schema to match new schema

# Summary of testing

- Add `Story4.json` test case

# Steps required for deployment

n/a
