### PR TITLE
Support the Result type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ let bbcNews = BbcNews()
 let bbcNews = BbcNews(modelIdentifier: "iPhone15,2", systemName: "iOS", systemVersion: "17.0")
 
 // Get results from the home page
-let results = try await bbcNews.fetchIndexDiscoveryPage(postcode: "W1A")
+let results = try await bbcNews.fetchIndexDiscoveryPageThrowing(postcode: "W1A")
 
 // Get results from a topic page
-let results = try await bbcNews.fetchTopicDiscoveryPage(for: "c50znx8v8y4t")
+let results = try await bbcNews.fetchTopicDiscoveryPageThrowing(for: "c50znx8v8y4t")
 
 // Parse story promo from a set of discovery results and fetch the full contents of that story
 for item in results.data.items {
@@ -37,8 +37,30 @@ for item in results.data.items {
         let url = storyPromo.link.destinations[0].url 
 
         // Get the full contents of the story
-        let story = try await bbcNews.fetch(url: url) 
+        let story = try await bbcNews.fetchThrowing(url: url) 
     }
+}
+```
+
+#### Swift 5 Result type
+
+All methods have equivalents to support both the Swift 5 Result type and traditional try-catch.
+You can use the try-catch equivalents by appending `Throwing` to the end of a method name. 
+
+try-catch:
+```swift
+let results = try await bbcNews.fetchIndexDiscoveryPageThrowing(postcode: "W1A")
+print(results) // [...]
+```
+
+Result type:
+```swift
+let result = await bbcNews.fetchIndexDiscoveryPage(postcode: "W1A")
+switch result {
+case .success(let results):
+    print(results) // [...]
+case .failure(let error):
+    print(error)
 }
 ```
 

--- a/Sources/BbcNews/Utils/JSONDecoder+DecodeWithoutThrowing.swift
+++ b/Sources/BbcNews/Utils/JSONDecoder+DecodeWithoutThrowing.swift
@@ -1,0 +1,24 @@
+//
+//  JSONDecoder+DecodeWithoutThrowing.swift
+//  BbcNews
+//
+//  Created by Bilaal Rashid on 09/07/2024.
+//
+
+import Foundation
+
+extension JSONDecoder {
+    /// Returns a value of the type you specify, decoded from a JSON object.
+    ///
+    /// - Parameters:
+    ///   - type: The type of the value to decode from the supplied JSON object.
+    ///   - data: The JSON object to decode.
+    /// - Returns: A value of the specified type, if the decoder can parse the data.
+    func decodeWithoutThrowing<T>(_ type: T.Type, from data: Data) -> Result<T, Error> where T: Decodable {
+        do {
+            return .success(try self.decode(type, from: data))
+        } catch let error {
+            return .failure(error)
+        }
+    }
+}

--- a/Sources/BbcNews/Utils/NetworkError.swift
+++ b/Sources/BbcNews/Utils/NetworkError.swift
@@ -26,6 +26,12 @@ public enum NetworkError: Error, LocalizedError, CustomStringConvertible {
     /// The server returned a new destination to resolve the requested response from.
     case newDestination(url: URL, link: FDLink)
 
+    /// A response was returned that was unable to be decoded into a type.
+    case undecodableResponse(url: URL, type: Decodable.Type, underlyingError: DecodingError)
+
+    /// A generic error encountered when performing a networking operation.
+    case generic(underlyingError: Error)
+
     /// A human-readable description describing the error.
     public var description: String {
         switch self {
@@ -39,6 +45,26 @@ public enum NetworkError: Error, LocalizedError, CustomStringConvertible {
             return "\(url) returned an unsuccessful HTTP response code (\(code))"
         case .newDestination(let url, let link):
             return "\(url) provides a new destination to resolve (\(link))"
+        case .undecodableResponse(let url, let type, let underlyingError):
+            // Manually rewrite the error description to be more useful when unwrapped
+            var description = ""
+
+            switch underlyingError {
+            case .dataCorrupted(let context):
+                description = "Data corrupted when decoding: \(context)"
+            case .keyNotFound(let key, let context):
+                description = "Key \(key) not found for coding path '\(context.codingPath)': \(context.debugDescription)"
+            case .valueNotFound(let value, let context):
+                description = "Value \(value) not found for coding path '\(context.codingPath)': \(context.debugDescription)"
+            case .typeMismatch(let type, let context):
+                description = "Type \(type) mismatch for coding path '\(context.codingPath)': \(context.debugDescription)"
+            @unknown default:
+                description = "Decoding error: \(underlyingError.localizedDescription)"
+            }
+
+            return "\(url) returned a response that was not decodable to \(type): \(description)"
+        case .generic(let underlyingError):
+            return underlyingError.localizedDescription.description
         }
     }
 
@@ -55,6 +81,10 @@ public enum NetworkError: Error, LocalizedError, CustomStringConvertible {
             return NSLocalizedString(self.description, comment: "Unsuccessful HTTP request")
         case .newDestination:
             return NSLocalizedString(self.description, comment: "New destination provided")
+        case .undecodableResponse:
+            return NSLocalizedString(self.description, comment: "Unable to decode response")
+        case .generic(let underlyingError):
+            return underlyingError.localizedDescription
         }
     }
 }


### PR DESCRIPTION
# Related issues

Closes #16 

# Summary of changes

- Create two versions of each method that returns an error: one using the Result type, the other using throws
- Update README to reflect the new syntax

# Summary of testing

Tests pass

# Steps required for deployment

n/a
