### PR TITLE
Use chrysalis_discovery parameter for english index discovery pages

### DIFF
--- a/Sources/BbcNews/BbcNews.swift
+++ b/Sources/BbcNews/BbcNews.swift
@@ -222,7 +222,7 @@ public struct BbcNews {
         components.queryItems = [
             URLQueryItem(name: "clientName", value: self.service.clientName),
             URLQueryItem(name: "clientVersion", value: BbcNews.clientVersion),
-            URLQueryItem(name: "page", value: "front_page"),
+            URLQueryItem(name: "page", value: self.service.indexPage),
             URLQueryItem(name: "service", value: self.service.service),
             URLQueryItem(name: "type", value: "index")
         ]

--- a/Sources/BbcNews/Models/Request/Service.swift
+++ b/Sources/BbcNews/Models/Request/Service.swift
@@ -80,4 +80,13 @@ public enum Service: String, Codable, Equatable, Hashable, Sendable, CaseIterabl
             return "russian"
         }
     }
+
+    /// The value of the `page` URL parameter to use when querying the index discovery page for this service.
+    public var indexPage: String {
+        if self == .english {
+            return "chrysalis_discovery"
+        }
+
+        return "front_page"
+    }
 }


### PR DESCRIPTION
# Related issues

Resolves #53 

# Summary of changes

- Use `chrysalis_discovery` parameter for english index discovery pages.

# Summary of testing

n/a

# Steps required for deployment

n/a
