### PR TITLE
Switch CI back to swift-actions/setup-swift

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Swift
-        uses: NeedleInAJayStack/setup-swift@feat/swift-6
+        uses: swift-actions/setup-swift@v2
         with:
           swift-version: ${{ matrix.swift }}
 


### PR DESCRIPTION
# Related issues

#55 

# Summary of changes

Swift 6 support has now been added upstream so we can move back to the main repo

# Summary of testing

The CI still runs and passes tests

# Steps required for deployment

n/a
